### PR TITLE
fix: log actual method errors instead of custom errors (#71)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func Set(key, value string) error {
 		err = openConfigFile.Close()
 	}(openConfigFile)
 	if err != nil {
-		logger.Error(ErrGetOpenFile.Error())
+		logger.Error(err.Error())
 		return ErrGetOpenFile
 	}
 
@@ -72,7 +72,7 @@ func Set(key, value string) error {
 
 	_, err = openConfigFile.WriteString(param)
 	if err != nil {
-		logger.Error(ErrWriteDataToOpenFile.Error())
+		logger.Error(err.Error())
 		return ErrWriteDataToOpenFile
 	}
 
@@ -86,7 +86,7 @@ func Set(key, value string) error {
 func Get(key string) string {
 	err := validateKey(key)
 	if err != nil {
-		logger.Error(ErrGetOpenFile.Error())
+		logger.Error(err.Error())
 		return EmptyValue
 	}
 
@@ -105,7 +105,7 @@ func Get(key string) string {
 		data := strings.Split(sc.Text(), Separator)
 
 		if len(data) != 2 {
-			logger.Error(ErrGetKeyValueData.Error())
+			logger.Error(err.Error())
 			return EmptyValue
 		}
 
@@ -151,7 +151,7 @@ func rewrite(key, value string) error {
 		err = openConfigFile.Close()
 	}(openConfigFile)
 	if err != nil {
-		logger.Error(ErrGetOpenFile.Error())
+		logger.Error(err.Error())
 		return ErrGetOpenFile
 	}
 
@@ -163,7 +163,7 @@ func rewrite(key, value string) error {
 		data := strings.Split(line, Separator)
 
 		if len(data) != 2 {
-			logger.Error(ErrGetKeyValueData.Error())
+			logger.Error(err.Error())
 			return ErrGetKeyValueData
 		}
 

--- a/internal/store/connection.go
+++ b/internal/store/connection.go
@@ -36,19 +36,19 @@ func GetConnections() (*connect.Connections, error) {
 
 	encryptedConnections, err := storage.Get(DirectionApp, FileConnections)
 	if err != nil {
-		logger.Error(ErrGetConnection.Error())
+		logger.Error(err.Error())
 		return nil, ErrGetConnection
 	}
 
 	decryptedConnections, err := crypto.Decrypt(encryptedConnections, cryptKey)
 	if err != nil {
-		logger.Error(ErrDecryptData.Error())
+		logger.Error(err.Error())
 		return nil, ErrDecryptData
 	}
 
 	err = json.Unmarshal([]byte(decryptedConnections), &connections)
 	if err != nil {
-		logger.Error(ErrUnmarshalJson.Error())
+		logger.Error(err.Error())
 		return nil, ErrUnmarshalJson
 	}
 
@@ -65,19 +65,19 @@ func SetConnections(connections *connect.Connections) error {
 
 	jsonConnections, err := json.Marshal(connections)
 	if err != nil {
-		logger.Error(ErrMarshalJson.Error())
+		logger.Error(err.Error())
 		return ErrMarshalJson
 	}
 
 	updatedEncryptedConnections, err := crypto.Encrypt(string(jsonConnections), cryptKey)
 	if err != nil {
-		logger.Error(ErrEncryptData.Error())
+		logger.Error(err.Error())
 		return ErrEncryptData
 	}
 
 	err = storage.Write(DirectionApp, FileConnections, updatedEncryptedConnections)
 	if err != nil {
-		logger.Error(ErrWriteJson.Error())
+		logger.Error(err.Error())
 		return ErrWriteJson
 	}
 

--- a/internal/store/crypt_key.go
+++ b/internal/store/crypt_key.go
@@ -23,7 +23,7 @@ func GetCryptKey() (string, error) {
 
 	cryptKey, err := keyring.Get(envconst.NameServiceCryptKey, username)
 	if err != nil {
-		logger.Error(ErrGetCryptKey.Error())
+		logger.Error(err.Error())
 		return "", err
 	}
 

--- a/internal/store/private_key.go
+++ b/internal/store/private_key.go
@@ -45,13 +45,13 @@ func SavePrivateKey(connection *connect.Connect) (string, error) {
 	direction, filename := storage.GetDirectionAndFilename(connection.SshOptions.PrivateKey)
 	dataPrivateKey, err := storage.Get(direction, filename)
 	if err != nil {
-		logger.Error(ErrGetDataPrivateKey.Error())
+		logger.Error(err.Error())
 		return "", ErrGetDataPrivateKey
 	}
 
 	err = validatePrivateKey(dataPrivateKey, connection.SshOptions.Passphrase)
 	if err != nil {
-		logger.Error(ErrNotValidPrivateKey.Error())
+		logger.Error(err.Error())
 		return "", err
 	}
 
@@ -59,13 +59,13 @@ func SavePrivateKey(connection *connect.Connect) (string, error) {
 
 	err = storage.Create(DirectionKeys, filenamePrivateKey)
 	if err != nil {
-		logger.Error(ErrCreateFilePrivateKey.Error())
+		logger.Error(err.Error())
 		return "", ErrCreateFilePrivateKey
 	}
 
 	err = storage.Write(DirectionKeys, filenamePrivateKey, dataPrivateKey)
 	if err != nil {
-		logger.Error(ErrWriteToFilePrivateKey.Error())
+		logger.Error(err.Error())
 		return "", ErrWriteToFilePrivateKey
 	}
 
@@ -96,14 +96,14 @@ func UpdatePrivateKey(connection *connect.Connect) (string, error) {
 
 	existDataPrivateKey, err := storage.Get(DirectionKeys, existFilenamePrivateKey)
 	if err != nil {
-		logger.Error(ErrGetDataPrivateKey.Error())
+		logger.Error(err.Error())
 		return "", ErrGetDataPrivateKey
 	}
 
 	direction, filename := storage.GetDirectionAndFilename(connection.SshOptions.PrivateKey)
 	dataPrivateKey, err := storage.Get(direction, filename)
 	if err != nil {
-		logger.Error(ErrGetDataPrivateKey.Error())
+		logger.Error(err.Error())
 		return "", ErrGetDataPrivateKey
 	}
 

--- a/pkg/kernel/connect.go
+++ b/pkg/kernel/connect.go
@@ -26,13 +26,13 @@ func Connect(connection *connect.Connect) error {
 
 		session, err := ssh.Session()
 		if err != nil {
-			logger.Error(ErrSshSession)
+			logger.Error(err.Error())
 			return ErrSshSession
 		}
 
 		err = ssh.Connect(session)
 		if err != nil {
-			logger.Error(ErrSshConnect)
+			logger.Error(err.Error())
 			return ErrSshConnect
 		}
 	default:

--- a/pkg/kernel/create.go
+++ b/pkg/kernel/create.go
@@ -28,7 +28,7 @@ func Create(connection *connect.Connect) error {
 
 	connections, err := store.GetConnections()
 	if err != nil {
-		logger.Error(ErrGetConnectionAtCreate.Error())
+		logger.Error(err.Error())
 		return ErrGetConnectionAtCreate
 	}
 
@@ -42,7 +42,7 @@ func Create(connection *connect.Connect) error {
 	if len(connection.SshOptions.PrivateKey) != 0 {
 		connection.SshOptions.PrivateKey, err = store.SavePrivateKey(connection)
 		if err != nil {
-			logger.Error(ErrSavePrivateKeyAtCreate.Error())
+			logger.Error(err.Error())
 			return err
 		}
 	}
@@ -54,12 +54,12 @@ func Create(connection *connect.Connect) error {
 		if len(connection.SshOptions.PrivateKey) != 0 {
 			errDeleteKey := store.DeletePrivateKey(connection)
 			if errDeleteKey != nil {
-				logger.Error(ErrDeletePrivateKeyAtCreate.Error())
+				logger.Error(errDeleteKey.Error())
 				return ErrDeletePrivateKeyAtCreate
 			}
 		}
 
-		logger.Error(ErrSetConnectionAtCreate.Error())
+		logger.Error(err.Error())
 		return ErrSetConnectionAtCreate
 	}
 

--- a/pkg/kernel/delete.go
+++ b/pkg/kernel/delete.go
@@ -21,7 +21,7 @@ func Delete(connection *connect.Connect) error {
 
 	connections, err := store.GetConnections()
 	if err != nil {
-		logger.Error(ErrGetConnectionAtDelete.Error())
+		logger.Error(err.Error())
 		return ErrGetConnectionAtDelete
 	}
 
@@ -31,7 +31,7 @@ func Delete(connection *connect.Connect) error {
 
 			err = store.SetConnections(connections)
 			if err != nil {
-				logger.Error(ErrSetConnectionAtDelete.Error())
+				logger.Error(err.Error())
 				return ErrSetConnectionAtDelete
 			}
 

--- a/pkg/kernel/list.go
+++ b/pkg/kernel/list.go
@@ -17,7 +17,7 @@ func List() (*connect.Connections, error) {
 
 	connections, err := store.GetConnections()
 	if err != nil {
-		logger.Error(ErrGetConnectionAtList.Error())
+		logger.Error(err.Error())
 		return nil, ErrGetConnectionAtList
 	}
 

--- a/pkg/kernel/update.go
+++ b/pkg/kernel/update.go
@@ -27,7 +27,7 @@ func Update(connection *connect.Connect, oldAlias string) error {
 
 	connections, err := store.GetConnections()
 	if err != nil {
-		logger.Error(ErrGetConnectionAtUpdate.Error())
+		logger.Error(err.Error())
 		return ErrGetConnectionAtUpdate
 	}
 
@@ -35,7 +35,7 @@ func Update(connection *connect.Connect, oldAlias string) error {
 		if savedConnection.Alias == oldAlias {
 			connection.SshOptions.PrivateKey, err = store.UpdatePrivateKey(connection)
 			if err != nil {
-				logger.Error(ErrSavePrivateKeyAtUpdate.Error())
+				logger.Error(err.Error())
 				return ErrSavePrivateKeyAtUpdate
 			}
 
@@ -43,7 +43,7 @@ func Update(connection *connect.Connect, oldAlias string) error {
 
 			err = store.SetConnections(connections)
 			if err != nil {
-				logger.Error(ErrSetConnectionAtUpdate.Error())
+				logger.Error(err.Error())
 				return ErrSetConnectionAtUpdate
 			}
 


### PR DESCRIPTION
## 🎯 Description
Fixes #71 

This PR replaces custom error logging with actual method error details throughout the codebase to provide better debugging information in logs.

## 📝 Changes Made

### Modified Files:
- `pkg/kernel/list.go`
- `pkg/kernel/connect.go`
- `pkg/kernel/create.go`
- `pkg/kernel/update.go`
- `pkg/kernel/delete.go`
- `internal/store/connection.go`
- `internal/store/private_key.go`
- `internal/store/crypt_key.go`
- `internal/config/config.go`

### What Changed:
**Before:** `logger.Error(ErrCustomMessage.Error())` 

**After:** `logger.Error(err.Error())` - logs actual error with full details from underlying methods

## 📸 Example

**Before:**
```go
connections, err := store.GetConnections()
if err != nil {
    logger.Error(ErrGetConnectionAtList.Error()) // Logs: "err get connections"
    return nil, ErrGetConnectionAtList
}
```

**After:**
```go
connections, err := store.GetConnections()
if err != nil {
    logger.Error(err.Error()) // Logs: actual detailed error from store.GetConnections()
    return nil, ErrGetConnectionAtList
}
```

## 🔗 Related
Closes #71

cc @deniskorbakov

---